### PR TITLE
[SWAT] Deprecates/Removes UIVisualEffectView on labels

### DIFF
--- a/MMNotifications/MMBannerNotificationView.m
+++ b/MMNotifications/MMBannerNotificationView.m
@@ -132,18 +132,7 @@
     
     _messageLabel = messageLabel;
     
-    if (visualEffectsSupported && backgroundBlurEffect) {
-        UIVibrancyEffect *vibrancyEffect = [UIVibrancyEffect effectForBlurEffect:backgroundBlurEffect];
-        UIVisualEffectView *messageContainer = [[UIVisualEffectView alloc] initWithEffect:vibrancyEffect];
-        messageContainer.userInteractionEnabled = NO;
-        
-        [contentContainers addObject:messageContainer];
-        
-        [messageContainer.contentView addSubview:messageLabel];
-        [contentView addSubview:messageContainer];
-    } else {
-        [contentView addSubview:messageLabel];
-    }
+    [contentView addSubview:messageLabel];
     
     // Image view.
     UIImageView *imageView = [[UIImageView alloc] initWithImage:notification.image];
@@ -485,7 +474,11 @@
 
 - (UIColor *)_messageTextColor
 {
-    return nil;
+    if (@available(iOS 13.0, *)) {
+        return [UIColor secondaryLabelColor];
+    } else {
+        return nil;
+    }
 }
 
 - (UIColor *)_titleTextColor


### PR DESCRIPTION
## What does this PR do?
- Remove use of visualEffects on the message label.
- Change default message text color to secondaryLabelColor.

## Shortcut Ticket:
[sc-16636](https://app.shortcut.com/cornershop-customers/story/16636/push-notifications-aren-t-readable-when-iphone-is-in-dark-mode)

## How does it look now?
<img src="https://user-images.githubusercontent.com/57687819/153928915-9e360f4d-af6d-4374-a6b4-7723befe4a4b.PNG" width=300> <img src="https://user-images.githubusercontent.com/57687819/153930099-f5abf47c-c509-4455-b1f4-ebb980aee97c.PNG" width=300>


